### PR TITLE
Clean headers and add doctests

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Main application and helper functions for the MewbileTech demo."""
 import datetime
 import json
 
@@ -153,11 +141,7 @@ if __name__ == '__main__':
     customers = create_customers(input_dictionary)
     process_event_history(input_dictionary, customers)
 
-    # ----------------------------------------------------------------------
-    # NOTE: You do not need to understand any of the implementation below,
-    # to be able to solve this assignment. However, feel free to
-    # read it anyway, just to get a sense of how the application runs.
-    # ----------------------------------------------------------------------
+
 
     # Gather all calls to be drawn on screen for filtering, but we only want
     # to plot each call only once, so only plot the outgoing calls to screen.

--- a/bill.py
+++ b/bill.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Representation of a monthly phone bill."""
 from typing import Union
 
 
@@ -86,16 +74,18 @@ class Bill:
         self.free_min += minutes
 
     def get_cost(self) -> float:
-        """ Return bill amount, considering the rates for billable calls for
-        this Bill's contract type.
+        """Return the total cost for this bill.
+
+        >>> b = Bill()
+        >>> b.add_billed_minutes(10)
+        >>> b.set_rates('MTM', 0.5)
+        >>> b.add_fixed_cost(10)
+        >>> b.get_cost()
+        15.0
         """
         return self.min_rate * self.billed_min + self.fixed_cost
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following method, to be able to solve this assignment
-    # but feel free to read it to get a sense of what it does.
-    # ----------------------------------------------------------
+
 
     def get_summary(self) -> dict[str, Union[float, int]]:
         """ Return a bill summary as a dictionary containing the bill details.

--- a/call.py
+++ b/call.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Call records and associated drawing utilities."""
 import datetime
 import os
 from typing import Optional
@@ -22,11 +10,7 @@ START_CALL_SPRITE = 'data/call-start-2.png'
 END_CALL_SPRITE = 'data/call-end-2.png'
 
 
-# ----------------------------------------------------------------------------
-# NOTE: You do not need to understand the implementation of the Drawable class
-# to be able to solve this assignment. However, feel feel free to read it for
-# the fun of understanding the visualization system.
-# ----------------------------------------------------------------------------
+
 
 class Drawable:
     """A class for objects that the graphical renderer can draw.
@@ -132,16 +116,16 @@ class Call:
         self.connection = Drawable(linelimits=(src_loc, dst_loc))
 
     def get_bill_date(self) -> tuple[int, int]:
-        """ Return the billing date for this Call, as a tuple containing the
-        month and the year
+        """Return the billing month and year.
+
+        >>> import datetime
+        >>> c = Call('a', 'b', datetime.datetime(2022, 1, 1, 0, 0), 60, (0, 0), (1, 1))
+        >>> c.get_bill_date()
+        (1, 2022)
         """
         return self.time.month, self.time.year
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
+
 
     def get_drawables(self) -> list[Drawable]:
         """ Return the list of drawable sprites for this Call

--- a/callhistory.py
+++ b/callhistory.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Storage of incoming and outgoing call records for a phone number."""
 from call import Call
 
 
@@ -53,11 +41,7 @@ class CallHistory:
         else:
             self.incoming_calls[find] = [call]
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
+
 
     def get_monthly_history(self, month: int = None, year: int = None) -> \
             tuple[list[Call], list[Call]]:

--- a/contract.py
+++ b/contract.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Contracts for phone lines and their billing behaviour."""
 import datetime
 from math import ceil
 from typing import Optional
@@ -65,7 +53,6 @@ class Contract:
         Store the <bill> argument in this contract and set the appropriate rate
         per minute and fixed cost.
 
-        DO NOT CHANGE THIS METHOD
         """
         raise NotImplementedError
 

--- a/customer.py
+++ b/customer.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Customer information and billing utilities."""
 from typing import Union
 from phoneline import PhoneLine
 from call import Call
@@ -78,11 +66,7 @@ class Customer:
                 fee = pl.cancel_line()
         return fee
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
+
 
     def add_phone_line(self, pline: PhoneLine) -> None:
         """ Add a new PhoneLine to this customer.

--- a/filter.py
+++ b/filter.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Filters used for searching and viewing call data."""
 import time
 import datetime
 

--- a/phoneline.py
+++ b/phoneline.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""A phone line owned by a customer."""
 from typing import Optional, Union
 from call import Call
 from callhistory import CallHistory
@@ -94,11 +82,7 @@ class PhoneLine:
         """
         return self.contract.cancel_contract()
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
+
 
     def get_number(self) -> str:
         """ Return the phone number for this line

--- a/sample_tests.py
+++ b/sample_tests.py
@@ -1,16 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
+"""Lightweight sample tests for the billing system."""
 import datetime
 
 import pytest

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,27 +1,4 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-
-=== Module Description ===
-
-This file contains the Visualizer class, which is responsible for interacting
-with Pygame, the graphics library we're using for this assignment.
-There's quite a bit in this file, but you aren't responsible for most of it.
-
-It also contains the Map class, which is responsible for converting between
-longitude/latitude coordinates and pixel coordinates on the pygame window.
-
-DO NOT CHANGE ANY CODE IN THIS FILE, unless instructed in the handout.
-"""
+"""Pygame-based visualizer used to display call activity."""
 import math
 import os
 import threading
@@ -33,13 +10,14 @@ import pygame
 
 from call import Drawable, Call
 from customer import Customer
-from filter import Filter, DurationFilter, CustomerFilter, LocationFilter, ResetFilter
+from filter import (
+    Filter,
+    DurationFilter,
+    CustomerFilter,
+    LocationFilter,
+    ResetFilter,
+)
 
-# ----------------------------------------------------------------------------
-# NOTE: You do not need to understand any of the visualization details from
-# this module, to be able to solve this assignment. However, feel free to read
-# it for the fun of understanding the visualization system.
-# ----------------------------------------------------------------------------
 
 WHITE = (255, 255, 255)
 LINE_COLOUR = (0, 64, 125)


### PR DESCRIPTION
## Summary
- remove University of Toronto copyright headers
- drop instructional comments
- provide short module docstrings
- add doctests for `Bill.get_cost` and `Call.get_bill_date`

## Testing
- `pytest sample_tests.py::test_customer_creation -q` *(fails: ModuleNotFoundError: No module named 'pygame')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae64d9ca8832c9835a335c636db17