### PR TITLE
remove comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,3 @@ this application.
    suite.
 2. Run `python application.py` to launch the visual interface.
 3. Sample tests can be executed with `pytest sample_tests.py`.
-
-## Notes on Errors
-
-Running the tests in this environment fails because the `pygame` package is not
-installed.  The application also expects the dataset and image assets to be
-located in the `data/` directory.  Ensure that this directory exists and
-contains the required files as documented in `ASSETS.md`.

--- a/application.py
+++ b/application.py
@@ -143,11 +143,6 @@ if __name__ == '__main__':
     customers = create_customers(input_dictionary)
     process_event_history(input_dictionary, customers)
 
-    # ----------------------------------------------------------------------
-    # NOTE: You do not need to understand any of the implementation below,
-    # to be able to solve this assignment. However, feel free to
-    # read it anyway, just to get a sense of how the application runs.
-    # ----------------------------------------------------------------------
 
     # Gather all calls to be drawn on screen for filtering, but we only want
     # to plot each call only once, so only plot the outgoing calls to screen.

--- a/bill.py
+++ b/bill.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 from typing import Union
 
 
@@ -91,11 +78,6 @@ class Bill:
         """
         return self.min_rate * self.billed_min + self.fixed_cost
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following method, to be able to solve this assignment
-    # but feel free to read it to get a sense of what it does.
-    # ----------------------------------------------------------
 
     def get_summary(self) -> dict[str, Union[float, int]]:
         """ Return a bill summary as a dictionary containing the bill details.

--- a/call.py
+++ b/call.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 import datetime
 import os
 from typing import Optional
@@ -22,11 +9,6 @@ START_CALL_SPRITE = 'data/call-start-2.png'
 END_CALL_SPRITE = 'data/call-end-2.png'
 
 
-# ----------------------------------------------------------------------------
-# NOTE: You do not need to understand the implementation of the Drawable class
-# to be able to solve this assignment. However, feel feel free to read it for
-# the fun of understanding the visualization system.
-# ----------------------------------------------------------------------------
 
 class Drawable:
     """A class for objects that the graphical renderer can draw.
@@ -137,11 +119,6 @@ class Call:
         """
         return self.time.month, self.time.year
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
 
     def get_drawables(self) -> list[Drawable]:
         """ Return the list of drawable sprites for this Call

--- a/callhistory.py
+++ b/callhistory.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 from call import Call
 
 
@@ -53,11 +40,6 @@ class CallHistory:
         else:
             self.incoming_calls[find] = [call]
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
 
     def get_monthly_history(self, month: int = None, year: int = None) -> \
             tuple[list[Call], list[Call]]:

--- a/contract.py
+++ b/contract.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 import datetime
 from math import ceil
 from typing import Optional
@@ -65,7 +52,6 @@ class Contract:
         Store the <bill> argument in this contract and set the appropriate rate
         per minute and fixed cost.
 
-        DO NOT CHANGE THIS METHOD
         """
         raise NotImplementedError
 

--- a/customer.py
+++ b/customer.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 from typing import Union
 from phoneline import PhoneLine
 from call import Call
@@ -78,11 +65,6 @@ class Customer:
                 fee = pl.cancel_line()
         return fee
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
 
     def add_phone_line(self, pline: PhoneLine) -> None:
         """ Add a new PhoneLine to this customer.

--- a/filter.py
+++ b/filter.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 import time
 import datetime
 

--- a/phoneline.py
+++ b/phoneline.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 from typing import Optional, Union
 from call import Call
 from callhistory import CallHistory
@@ -94,11 +81,6 @@ class PhoneLine:
         """
         return self.contract.cancel_contract()
 
-    # ----------------------------------------------------------
-    # NOTE: You do not need to understand the implementation of
-    # the following methods, to be able to solve this assignment
-    # but feel free to read them to get a sense of what these do.
-    # ----------------------------------------------------------
 
     def get_number(self) -> str:
         """ Return the phone number for this line

--- a/sample_tests.py
+++ b/sample_tests.py
@@ -1,16 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-"""
 import datetime
 
 import pytest

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,27 +1,3 @@
-"""
-CSC148, Winter 2025
-Assignment 1
-
-This code is provided solely for the personal and private use of
-students taking the CSC148 course at the University of Toronto.
-Copying for purposes other than this use is expressly prohibited.
-All forms of distribution of this code, whether as given or with
-any changes, are expressly prohibited.
-
-All of the files in this directory and all subdirectories are:
-Copyright (c) 2025 Bogdan Simion, Diane Horton, Jacqueline Smith
-
-=== Module Description ===
-
-This file contains the Visualizer class, which is responsible for interacting
-with Pygame, the graphics library we're using for this assignment.
-There's quite a bit in this file, but you aren't responsible for most of it.
-
-It also contains the Map class, which is responsible for converting between
-longitude/latitude coordinates and pixel coordinates on the pygame window.
-
-DO NOT CHANGE ANY CODE IN THIS FILE, unless instructed in the handout.
-"""
 import math
 import os
 import threading
@@ -35,11 +11,6 @@ from call import Drawable, Call
 from customer import Customer
 from filter import Filter, DurationFilter, CustomerFilter, LocationFilter, ResetFilter
 
-# ----------------------------------------------------------------------------
-# NOTE: You do not need to understand any of the visualization details from
-# this module, to be able to solve this assignment. However, feel free to read
-# it for the fun of understanding the visualization system.
-# ----------------------------------------------------------------------------
 
 WHITE = (255, 255, 255)
 LINE_COLOUR = (0, 64, 125)


### PR DESCRIPTION
## Summary
- strip copyright notices referencing the University of Toronto
- delete instructional comments about not changing the files
- remove "Notes on Errors" from the README

## Testing
- `pytest -q`
- `pytest sample_tests.py -q` *(fails: ModuleNotFoundError: No module named 'pygame')*

------
https://chatgpt.com/codex/tasks/task_e_684af30f0df8832c981df4aca70ddb4b